### PR TITLE
Add Living Dead buff_id to WHM buff list

### DIFF
--- a/GeneralTriggers/Qwert/General_WHM_everywhere.lua
+++ b/GeneralTriggers/Qwert/General_WHM_everywhere.lua
@@ -7005,6 +7005,7 @@ local tbl =
 					409,
 					1836,
 					811,
+					810
 				},
 				category = 3,
 				channelCheckSpellID = -1,
@@ -7806,6 +7807,7 @@ local tbl =
 					409,
 					1836,
 					811,
+					810
 				},
 				category = 3,
 				channelCheckSpellID = -1,

--- a/GeneralTriggers/Qwert/General_WHM_savage.lua
+++ b/GeneralTriggers/Qwert/General_WHM_savage.lua
@@ -6075,6 +6075,7 @@ local tbl =
 					409,
 					1836,
 					811,
+					810
 				},
 				category = 3,
 				channelCheckSpellID = -1,
@@ -6875,6 +6876,7 @@ local tbl =
 					409,
 					1836,
 					811,
+					810
 				},
 				category = 3,
 				channelCheckSpellID = -1,


### PR DESCRIPTION
I'm not sure if it was intended or not to leave off the LD buff_id or not, but my DRK was dieing (in a party finder) and by adding it he stopped dieing, so figured I'd throw it out there to you and see if you want it in there.